### PR TITLE
Fix vet errors in command formatting

### DIFF
--- a/internal/handler/commands/apb.go
+++ b/internal/handler/commands/apb.go
@@ -20,7 +20,7 @@ func (bc BotCommand) Apb(event BotCommand) error {
 		response.Message = fmt.Sprintf(`/me sends out the blood hounds to find %s`, event.body)
 	} else {
 		response.Type = "dm"
-		response.Message = fmt.Sprintf(`Who's ` + event.body + `?`)
+		response.Message = fmt.Sprintf("Who's %s?", event.body)
 	}
 
 	event.ResponseChannel <- response

--- a/internal/handler/commands/insult.go
+++ b/internal/handler/commands/insult.go
@@ -39,7 +39,7 @@ func (bc BotCommand) Insult(event BotCommand) error {
 		response.Message = strings.Replace(response.Message, "{0}", event.body, -1)
 	} else {
 		response.Type = "dm"
-		response.Message = fmt.Sprintf(`Who's ` + event.body + `?`)
+		response.Message = fmt.Sprintf("Who's %s?", event.body)
 	}
 
 	event.ResponseChannel <- response

--- a/internal/handler/commands/praise.go
+++ b/internal/handler/commands/praise.go
@@ -47,7 +47,7 @@ func (bc BotCommand) Praise(event BotCommand) error {
 		response.Message = strings.Replace(response.Message, "{0}", event.body, -1)
 	} else {
 		response.Type = "dm"
-		response.Message = fmt.Sprintf(`Who's ` + event.body + `?`)
+		response.Message = fmt.Sprintf("Who's %s?", event.body)
 	}
 
 	event.ResponseChannel <- response


### PR DESCRIPTION
## Summary
- avoid non-constant fmt.Sprintf format strings in commands

## Testing
- go test ./internal/handler/commands