### PR TITLE
Fix message ordering across channels

### DIFF
--- a/internal/comms/comms_order_test.go
+++ b/internal/comms/comms_order_test.go
@@ -38,6 +38,7 @@ func TestMessageOrderingTableDriven(t *testing.T) {
 				ResponseCh: make(chan Response, len(tt.msgs)),
 				expected:   make(map[string]uint64),
 				pending:    make(map[string]map[uint64]*Response),
+				nextSeq:    make(map[string]uint64),
 			}
 
 			got := make(map[string][]uint64)


### PR DESCRIPTION
## Summary
- sequence messages per channel so a message in one channel does not block another
- initialize per-channel sequence counter

## Testing
- go test ./internal/comms -run TestMessageOrderingTableDriven
- go test ./internal/handler -run TestHandleCommand_ChannelResolution